### PR TITLE
サーバ構築7回目の授業

### DIFF
--- a/07/aqua.yaml
+++ b/07/aqua.yaml
@@ -9,10 +9,10 @@
 #   - all
 registries:
 - type: standard
-  ref: v4.381.1 # renovate: depName=aquaproj/aqua-registry
+  ref: v4.385.0 # renovate: depName=aquaproj/aqua-registry
 packages:
 - name: kubernetes-sigs/kind@v0.29.0
 - name: kubernetes/kubernetes/kubectl@v1.33.2
-- name: derailed/k9s@v0.50.6
-- name: helm/helm@v3.18.3
+- name: derailed/k9s@v0.50.7
+- name: helm/helm@v3.18.4
 - name: kubernetes-sigs/kustomize@kustomize/v5.7.0

--- a/07/db-deployment.yaml
+++ b/07/db-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+      - name: mariadb
+        image: mariadb:11.8.1-ubi9-rc
+        ports:
+        - containerPort: 3306
+        envFrom:
+          - secretRef:
+              name: wordpress-secret
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        volumeMounts:
+        - name: db-data-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: db-data-storage
+        persistentVolumeClaim:
+          claimName: db-data-pvc

--- a/07/db-pvc.yaml
+++ b/07/db-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/07/db-service.yaml
+++ b/07/db-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+spec:
+  type: ClusterIP
+  selector:
+    app: mariadb
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306

--- a/07/kustomization.yaml
+++ b/07/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: default
+
+resources:
+- db-deployment.yaml
+- db-pvc.yaml
+- db-service.yaml
+- secret.yaml
+- wp-deployment.yaml
+- wp-pvc.yaml
+- wp-service.yaml

--- a/07/secret.yaml
+++ b/07/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wordpress-secret
+stringData:
+  MYSQL_ROOT_PASSWORD: 'password'
+  MYSQL_DATABASE: 'wordpress'
+  MYSQL_USER: 'wordpress_user'
+  MYSQL_PASSWORD: 'password'
+  WORDPRESS_DB_HOST: 'db:3306'
+  WORDPRESS_DB_USER: 'wordpress_user'
+  WORDPRESS_DB_PASSWORD: 'password'
+  WORDPRESS_DB_NAME: 'wordpress'

--- a/07/wp-deployment.yaml
+++ b/07/wp-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wordpress
+  template:
+    metadata:
+      labels:
+        app: wordpress
+    spec:
+      containers:
+      - name: wordpress
+        image: wordpress:6.8.1-php8.1-apache
+        ports:
+        - containerPort: 80
+        envFrom:
+          - secretRef:
+              name: wordpress-secret
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        volumeMounts:
+        - name: wp-data-storage
+          mountPath: /var/www/html
+      volumes:
+      - name: wp-data-storage
+        persistentVolumeClaim:
+          claimName: wp-data-pvc

--- a/07/wp-pvc.yaml
+++ b/07/wp-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wp-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/07/wp-service.yaml
+++ b/07/wp-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+spec:
+  type: ClusterIP
+  selector:
+    app: wordpress
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 80

--- a/07/作業ログ.md
+++ b/07/作業ログ.md
@@ -1,0 +1,10 @@
+# server-isn-2434
+
+## 7回目の授業
+```bash
+# ビルドしてクラスタに適用
+kustomize build . |kubectl apply -f -
+
+# クラスタに展開したサービスにアクセス出来るようにする
+kubectl port-forward service/wordpress 8080:8080
+```


### PR DESCRIPTION
## なぜやるか
- 他のツールと連携しやすい
- yamlを使うことで宣言的な構成管理ができる
- インフラをコードで扱うため
## なにをやったのか
- マニフェスト自分で書いた
- kustomizeでwordpressに合うようにマニフェストを描いた
## 動作確認の手順
- kustomize build . |kubectl apply -f -
- kubectl port-forward service/wordpress 8080:8080